### PR TITLE
Add Dockerfile and add Apache-2.0 license

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git/
+node_modules/
+test/

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,5 +1,10 @@
 ## Changelog
 
+### 0.1.0
+* Add license information
+* Mark project as public
+* Updated dependencies
+
 ### 0.0.2
 * Add HTTP dashboard, installed through github and accessible through /interface
 * Add helper REST routes for services (email, push, logging) to support HTTP dashboard

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 ## Changelog
 
 ### 0.1.0
+* Add Dockerfile
 * Add license information
 * Mark project as public
 * Updated dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 FROM kinvey/base_phusion_node

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN \
  groupadd -g 2010 kinvey && \
  useradd -m -s /usr/sbin/nologin -d /opt/kinvey -g kinvey -u 2010 -c "Kinvey Application User" kinvey && \
  apt-get update && apt-get -y dist-upgrade && \
+ apt-get -y install git && \
  mkdir -m 0755 /var/log/kinvey && \
  mkdir -m 0755 /etc/service/business-logic-mock-proxy && \
  chown -R kinvey:kinvey /var/log/kinvey && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,5 +41,4 @@ RUN \
 EXPOSE 2845
 WORKDIR /opt/kinvey/business-logic-mock-proxy
 RUN \
- npm uninstall business-logic-local-dashboard --save && \
  npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+#
+# This software is licensed to you under the Kinvey terms of service located at
+# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
+# software, you hereby accept such terms of service  (and any agreement referenced
+# therein) and agree that you have read, understand and agree to be bound by such
+# terms of service and are of legal age to agree to such terms with Kinvey.
+#
+# This software contains valuable confidential and proprietary information of
+# KINVEY, INC and is subject to applicable licensing agreements.
+# Unauthorized reproduction, transmission or distribution of this file and its
+# contents is a violation of applicable laws.
+#
+
+FROM kinvey/base_phusion_node
+MAINTAINER "Kinvey Inc."
+
+# Add pre-built application directory.
+ADD . /opt/kinvey/business-logic-mock-proxy
+
+# Create kinvey:kinvey group:user.
+RUN \
+ date -u +%F:%H:%M:%S > /etc/container_environment/BL_PROXY_BUILD_TIME && \
+ groupadd -g 2010 kinvey && \
+ useradd -m -s /usr/sbin/nologin -d /opt/kinvey -g kinvey -u 2010 -c "Kinvey Application User" kinvey && \
+ apt-get update && apt-get -y dist-upgrade && \
+ mkdir -m 0755 /var/log/kinvey && \
+ mkdir -m 0755 /etc/service/business-logic-mock-proxy && \
+ chown -R kinvey:kinvey /var/log/kinvey && \
+ chown -R kinvey:kinvey /opt/kinvey && \
+ chmod 0755 /etc/container_environment && \
+ chmod 0644 /etc/container_environment.sh /etc/container_environment.json
+
+ADD bin/blproxy.sh /etc/service/business-logic-mock-proxy/run
+
+RUN \
+ chmod 0755 /etc/service/business-logic-mock-proxy/run
+
+# Prepare to run the application.
+EXPOSE 2845
+WORKDIR /opt/kinvey/business-logic-mock-proxy
+RUN \
+ npm uninstall business-logic-local-dashboard --save && \
+ npm install

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -193,58 +193,58 @@ limitations under the License.
 
 Summary:
 
-* async-1.4        [MIT] - Asynchronuous flow handler.
-* body-parser-1.13 [MIT] - Request body parser.
-* bson-0.2.15      [Apache-2.0] - BSON handler.
-* busboy-0.2       [MIT] - Upload handler.
+* async-1.4.2          [MIT] - Asynchronuous flow handler.
+* body-parser-1.13.3   [MIT] - Request body parser.
+* bson-0.2.15          [Apache-2.0] - BSON handler.
+* busboy-0.2.11        [MIT] - Upload handler.
 * business-logic-local-dashboard-0.1.0 [Apache-2.0] - Web interface.
-* coffee-script-1.10 [MIT] - Project language.
-* coffeelint-1.11  [MIT] - Linting library.
-* config-1.16      [MIT] - Configuration management.
-* cors-2.7         [MIT] - Enables CORS for express.
-* express-4.13     [MIT] - Application framework.
-* JSONStream-0.10  [MIT] - JSON request body handler.
-* jszip-2.5        [MIT] - ZIP handler.
-* mocha-2.3        [MIT] - Testing framework.
-* node-zip-1.1     [MIT] - ZIP handler.
-* request-2.62     [Apache-2.0] - Request performer.
-* should-7.1       [MIT] - Assertion library.
-* tingodb-0.3.4    [MIT] - In-memory database.
-* underscore-1.8   [MIT] - Utility library.
-* uuid-2.0         [MIT] - ID generator.
+* coffee-script-1.10.0 [MIT] - Project language.
+* coffeelint-1.11.1    [MIT] - Linting library.
+* config-1.16.0        [MIT] - Configuration management.
+* cors-2.7.1           [MIT] - Enables CORS for express.
+* express-4.13.3       [MIT] - Application framework.
+* JSONStream-0.10.0    [MIT] - JSON request body handler.
+* jszip-2.5.0          [MIT] - ZIP handler.
+* mocha-2.3.2          [MIT] - Testing framework.
+* node-zip-1.1.1       [MIT] - ZIP handler.
+* request-2.62.0       [Apache-2.0] - Request performer.
+* should-7.1.0         [MIT] - Assertion library.
+* tingodb-0.3.4        [MIT] - In-memory database.
+* underscore-1.8.3     [MIT] - Utility library.
+* uuid-2.0.1           [MIT] - ID generator.
 
 
 SECTION 1: BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE LICENSES
 
-   >>> async-1.4
-   >>> body-parser-1.13
-   >>> busboy-0.2
-   >>> coffee-script-1.10
-   >>> coffeelint-1.11
-   >>> config-1.16
-   >>> cors-2.7
-   >>> express-4.13
-   >>> JSONStream-0.10
-   >>> jszip-2.5
-   >>> mocha-2.3
-   >>> node-zip-1.1
-   >>> should-7.1
+   >>> async-1.4.2
+   >>> body-parser-1.13.3
+   >>> busboy-0.2.15
+   >>> coffee-script-1.10.0
+   >>> coffeelint-1.11.1
+   >>> config-1.16.0
+   >>> cors-2.7.1
+   >>> express-4.13.3
+   >>> JSONStream-0.10.0
+   >>> jszip-2.5.0
+   >>> mocha-2.3.2
+   >>> node-zip-1.1-1
+   >>> should-7.1.0
    >>> tingodb-0.3.4
-   >>> underscore-1.8
-   >>> uuid-2.0
+   >>> underscore-1.8.3
+   >>> uuid-2.0.1
 
 SECTION 2: Apache License, V2.0
 
    >>> bson-0.2.15
    >>> business-logic-local-dashboard-0.1.0
-   >>> request-2.62
+   >>> request-2.62.0
 
 
 --------------- SECTION 1:  BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE LICENSES ----------
 
 BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE is applicable to the following component(s).
 
->>> async-1.4 (https://github.com/caolan/async/blob/master/LICENSE)
+>>> async-1.4.2 (https://github.com/caolan/async/blob/master/LICENSE)
 
 Copyright (c) 2010-2014 Caolan McMahon
 
@@ -267,7 +267,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
->>> body-parser-1.13 (https://github.com/expressjs/body-parser/blob/master/LICENSE)
+>>> body-parser-1.13.3 (https://github.com/expressjs/body-parser/blob/master/LICENSE)
 
 (The MIT License)
 
@@ -294,7 +294,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
->>> busboy-0.2 (https://github.com/mscdex/busboy/blob/master/LICENSE)
+>>> busboy-0.2.11 (https://github.com/mscdex/busboy/blob/master/LICENSE)
 
 Copyright Brian White. All rights reserved.
 
@@ -317,7 +317,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 
 
->>> coffee-script-1.10 (https://github.com/jashkenas/coffeescript/blob/master/LICENSE)
+>>> coffee-script-1.10.0 (https://github.com/jashkenas/coffeescript/blob/master/LICENSE)
 
 Copyright (c) 2009-2015 Jeremy Ashkenas
 
@@ -343,7 +343,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 
->>> coffeelint-1.11 (https://github.com/clutchski/coffeelint/blob/master/LICENSE)
+>>> coffeelint-1.11.1 (https://github.com/clutchski/coffeelint/blob/master/LICENSE)
 
 CoffeeLint
 Copyright (c) 2011 Matthew Perpick
@@ -367,7 +367,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 
->>> config-1.16 (https://github.com/lorenwest/node-config/blob/master/LICENSE)
+>>> config-1.16.0 (https://github.com/lorenwest/node-config/blob/master/LICENSE)
 
 // Copyright 2010-2015, Loren West and other contributors
 
@@ -390,7 +390,7 @@ THE SOFTWARE.
 // IN THE SOFTWARE.
 
 
->>> cors-2.7 (https://github.com/expressjs/cors/blob/master/LICENSE)
+>>> cors-2.7.1 (https://github.com/expressjs/cors/blob/master/LICENSE)
 
 The MIT License (MIT)
 
@@ -403,7 +403,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
->>> express-4.13 (https://github.com/strongloop/express/blob/master/LICENSE)
+>>> express-4.13.3 (https://github.com/strongloop/express/blob/master/LICENSE)
 
 (The MIT License)
 
@@ -431,7 +431,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
->>> JSONStream-0.10 (https://github.com/dominictarr/JSONStream/blob/master/LICENSE.MIT)
+>>> JSONStream-0.10.0 (https://github.com/dominictarr/JSONStream/blob/master/LICENSE.MIT)
 
 The MIT License
 
@@ -459,7 +459,7 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
->>> jszip-2.5 (https://github.com/Stuk/jszip/blob/master/LICENSE.markdown)
+>>> jszip-2.5.0 (https://github.com/Stuk/jszip/blob/master/LICENSE.markdown)
 
 The MIT License
 Copyright (c) 2009-2014 Stuart Knightley, David Duponchel, Franz Buchinger, António Afonso
@@ -471,7 +471,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
->>> mocha-2.3 (https://github.com/mochajs/mocha/blob/master/LICENSE)
+>>> mocha-2.3.2 (https://github.com/mochajs/mocha/blob/master/LICENSE)
 
 (The MIT License)
 
@@ -497,12 +497,12 @@ TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
->>> node-zip-1.1 (https://github.com/daraosn/node-zip/blob/master/README.md)
+>>> node-zip-1.1.1 (https://github.com/daraosn/node-zip/blob/master/README.md)
 
 MIT
 
 
->>> should-7.1 (https://github.com/shouldjs/should.js/blob/master/LICENSE)
+>>> should-7.1.0 (https://github.com/shouldjs/should.js/blob/master/LICENSE)
 
 Copyright (c) 2010-2014 TJ Holowaychuk <tj@vision-media.ca>
 
@@ -536,7 +536,7 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 
->>> underscore-1.8 (https://github.com/jashkenas/underscore/blob/master/LICENSE)
+>>> underscore-1.8.3 (https://github.com/jashkenas/underscore/blob/master/LICENSE)
 
 Copyright (c) 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative
 Reporters & Editors
@@ -563,7 +563,7 @@ FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
 
->>> uuid (https://github.com/defunctzombie/node-uuid/blob/master/LICENSE.md)
+>>> uuid-2.0.1 (https://github.com/defunctzombie/node-uuid/blob/master/LICENSE.md)
 
 Copyright (c) 2010-2012 Robert Kieffer MIT License - http://opensource.org/licenses/mit-license.php
 
@@ -792,7 +792,7 @@ KINVEY, INC and is subject to applicable licensing agreements.
 Unauthorized reproduction, transmission or distribution of this file and its
 contents is a violation of applicable laws.
 
->>> request-2.62 (https://github.com/request/request/blob/master/LICENSE)
+>>> request-2.62.0 (https://github.com/request/request/blob/master/LICENSE)
 
 Apache License
 

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,851 @@
+Copyright 2015 Kinvey, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+
+Summary:
+
+* async-1.4        [MIT] - Asynchronuous flow handler.
+* body-parser-1.13 [MIT] - Request body parser.
+* bson-0.2.15      [Apache-2.0] - BSON handler.
+* busboy-0.2       [MIT] - Upload handler.
+* business-logic-local-dashboard-0.1.0 [Apache-2.0] - Web interface.
+* coffee-script-1.10 [MIT] - Project language.
+* coffeelint-1.11  [MIT] - Linting library.
+* config-1.16      [MIT] - Configuration management.
+* cors-2.7         [MIT] - Enables CORS for express.
+* express-4.13     [MIT] - Application framework.
+* JSONStream-0.10  [MIT] - JSON request body handler.
+* jszip-2.5        [MIT] - ZIP handler.
+* mocha-2.3        [MIT] - Testing framework.
+* node-zip-1.1     [MIT] - ZIP handler.
+* request-2.62     [Apache-2.0] - Request performer.
+* should-7.1       [MIT] - Assertion library.
+* tingodb-0.3.4    [MIT] - In-memory database.
+* underscore-1.8   [MIT] - Utility library.
+* uuid-2.0         [MIT] - ID generator.
+
+
+SECTION 1: BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE LICENSES
+
+   >>> async-1.4
+   >>> body-parser-1.13
+   >>> busboy-0.2
+   >>> coffee-script-1.10
+   >>> coffeelint-1.11
+   >>> config-1.16
+   >>> cors-2.7
+   >>> express-4.13
+   >>> JSONStream-0.10
+   >>> jszip-2.5
+   >>> mocha-2.3
+   >>> node-zip-1.1
+   >>> should-7.1
+   >>> tingodb-0.3.4
+   >>> underscore-1.8
+   >>> uuid-2.0
+
+SECTION 2: Apache License, V2.0
+
+   >>> bson-0.2.15
+   >>> business-logic-local-dashboard-0.1.0
+   >>> request-2.62
+
+
+--------------- SECTION 1:  BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE LICENSES ----------
+
+BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE is applicable to the following component(s).
+
+>>> async-1.4 (https://github.com/caolan/async/blob/master/LICENSE)
+
+Copyright (c) 2010-2014 Caolan McMahon
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+>>> body-parser-1.13 (https://github.com/expressjs/body-parser/blob/master/LICENSE)
+
+(The MIT License)
+
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+>>> busboy-0.2 (https://github.com/mscdex/busboy/blob/master/LICENSE)
+
+Copyright Brian White. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+
+
+>>> coffee-script-1.10 (https://github.com/jashkenas/coffeescript/blob/master/LICENSE)
+
+Copyright (c) 2009-2015 Jeremy Ashkenas
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+
+>>> coffeelint-1.11 (https://github.com/clutchski/coffeelint/blob/master/LICENSE)
+
+CoffeeLint
+Copyright (c) 2011 Matthew Perpick
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+>>> config-1.16 (https://github.com/lorenwest/node-config/blob/master/LICENSE)
+
+// Copyright 2010-2015, Loren West and other contributors
+
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to
+// deal in the Software without restriction, including without limitation the
+// rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+// sell copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+// FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+// IN THE SOFTWARE.
+
+
+>>> cors-2.7 (https://github.com/expressjs/cors/blob/master/LICENSE)
+
+The MIT License (MIT)
+
+Copyright (c) 2013 Troy Goode <troygoode@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+>>> express-4.13 (https://github.com/strongloop/express/blob/master/LICENSE)
+
+(The MIT License)
+
+Copyright (c) 2009-2014 TJ Holowaychuk <tj@vision-media.ca>
+Copyright (c) 2013-2014 Roman Shtylman <shtylman+expressjs@gmail.com>
+Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+>>> JSONStream-0.10 (https://github.com/dominictarr/JSONStream/blob/master/LICENSE.MIT)
+
+The MIT License
+
+Copyright (c) 2011 Dominic Tarr
+
+Permission is hereby granted, free of charge,
+to any person obtaining a copy of this software and
+associated documentation files (the "Software"), to
+deal in the Software without restriction, including
+without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom
+the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR
+ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+>>> jszip-2.5 (https://github.com/Stuk/jszip/blob/master/LICENSE.markdown)
+
+The MIT License
+Copyright (c) 2009-2014 Stuart Knightley, David Duponchel, Franz Buchinger, António Afonso
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+>>> mocha-2.3 (https://github.com/mochajs/mocha/blob/master/LICENSE)
+
+(The MIT License)
+
+Copyright (c) 2011-2015 TJ Holowaychuk <tj@vision-media.ca>
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+>>> node-zip-1.1 (https://github.com/daraosn/node-zip/blob/master/README.md)
+
+MIT
+
+
+>>> should-7.1 (https://github.com/shouldjs/should.js/blob/master/LICENSE)
+
+Copyright (c) 2010-2014 TJ Holowaychuk <tj@vision-media.ca>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+>>> tingodb-0.3.4 (https://github.com/sergeyksv/tingodb)
+
+Copyright (c) PushOk Software
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+>>> underscore-1.8 (https://github.com/jashkenas/underscore/blob/master/LICENSE)
+
+Copyright (c) 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative
+Reporters & Editors
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+
+>>> uuid (https://github.com/defunctzombie/node-uuid/blob/master/LICENSE.md)
+
+Copyright (c) 2010-2012 Robert Kieffer MIT License - http://opensource.org/licenses/mit-license.php
+
+
+
+--------------- SECTION 2: Apache License, V2.0 ----------
+
+Apache License, V2.0 is applicable to the following component(s).
+
+>>> bson-0.2.15 (https://github.com/mongodb/js-bson/blob/master/LICENSE)
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+>>> business-logic-local-dashboard-0.1.0 (https://github.com/Kinvey/business-logic-local-dashboard/blob/master/LICENSE.txt)
+
+Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+
+This software is licensed to you under the Kinvey terms of service located at
+http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
+software, you hereby accept such terms of service  (and any agreement referenced
+therein) and agree that you have read, understand and agree to be bound by such
+terms of service and are of legal age to agree to such terms with Kinvey.
+
+This software contains valuable confidential and proprietary information of
+KINVEY, INC and is subject to applicable licensing agreements.
+Unauthorized reproduction, transmission or distribution of this file and its
+contents is a violation of applicable laws.
+
+>>> request-2.62 (https://github.com/request/request/blob/master/LICENSE)
+
+Apache License
+
+Version 2.0, January 2004
+
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner. For the purposes of this definition, "submitted" means any form of electronic, verbal, or written communication sent to the Licensor or its representatives, including but not limited to communication on electronic mailing lists, source code control systems, and issue tracking systems that are managed by, or on behalf of, the Licensor for the purpose of discussing and improving the Work, but excluding communication that is conspicuously marked or otherwise designated in writing by the copyright owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License. You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS

--- a/README.md
+++ b/README.md
@@ -45,15 +45,16 @@ npm run-script test-specificTestName
 Where `specificTestName` is one of `logging`, `collectionAccess`, `email`, `push`
 
 ## License
-    Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+    Copyright 2015 Kinvey, Inc.
 
-    This software is licensed to you under the Kinvey terms of service located at
-    http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-    software, you hereby accept such terms of service  (and any agreement referenced
-    therein) and agree that you have read, understand and agree to be bound by such
-    terms of service and are of legal age to agree to such terms with Kinvey.
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    #ou may obtain a copy of the License at
 
-    This software contains valuable confidential and proprietary information of
-    KINVEY, INC and is subject to applicable licensing agreements.
-    Unauthorized reproduction, transmission or distribution of this file and its
-    contents is a violation of applicable laws.
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.

--- a/README.md
+++ b/README.md
@@ -43,3 +43,17 @@ npm run-script test-specificTestName
 ```
 
 Where `specificTestName` is one of `logging`, `collectionAccess`, `email`, `push`
+
+## License
+    Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+
+    This software is licensed to you under the Kinvey terms of service located at
+    http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
+    software, you hereby accept such terms of service  (and any agreement referenced
+    therein) and agree that you have read, understand and agree to be bound by such
+    terms of service and are of legal age to agree to such terms with Kinvey.
+
+    This software contains valuable confidential and proprietary information of
+    KINVEY, INC and is subject to applicable licensing agreements.
+    Unauthorized reproduction, transmission or distribution of this file and its
+    contents is a violation of applicable laws.

--- a/bin/blproxy.sh
+++ b/bin/blproxy.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+#
+# This software is licensed to you under the Kinvey terms of service located at
+# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
+# software, you hereby accept such terms of service  (and any agreement referenced
+# therein) and agree that you have read, understand and agree to be bound by such
+# terms of service and are of legal age to agree to such terms with Kinvey.
+#
+# This software contains valuable confidential and proprietary information of
+# KINVEY, INC and is subject to applicable licensing agreements.
+# Unauthorized reproduction, transmission or distribution of this file and its
+# contents is a violation of applicable laws.
+#
+# `/sbin/setuser kinvey` runs the given command as the user `kinvey`.
+# If you omit that part, the command will be run as root.
+cd /opt/kinvey/business-logic-mock-proxy
+exec /sbin/setuser kinvey /usr/bin/node /opt/kinvey/business-logic-mock-proxy >> /var/log/blmockproxy.log 2>&1

--- a/bin/blproxy.sh
+++ b/bin/blproxy.sh
@@ -1,17 +1,18 @@
 #!/bin/bash
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 # `/sbin/setuser kinvey` runs the given command as the user `kinvey`.
 # If you omit that part, the command will be run as root.

--- a/config/default.coffee
+++ b/config/default.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 pkg = require '../package.json'

--- a/config/default.coffee
+++ b/config/default.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 pkg = require '../package.json'
 

--- a/index.js
+++ b/index.js
@@ -1,15 +1,18 @@
-// Copyright (c) 2014, Kinvey, Inc. All rights reserved.
-//
-// This software is licensed to you under the Kinvey terms of service located at
-// http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-// software, you hereby accept such terms of service  (and any agreement referenced
-// therein) and agree that you have read, understand and agree to be bound by such
-// terms of service and are of legal age to agree to such terms with Kinvey.
-//
-// This software contains valuable confidential and proprietary information of
-// KINVEY, INC and is subject to applicable licensing agreements.
-// Unauthorized reproduction, transmission or distribution of this file and its
-// contents is a violation of applicable laws.
+/**
+ * Copyright 2015 Kinvey, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 require('coffee-script/register')
 module.exports.ENTRY_POINT = 'index';

--- a/lib/data-store.coffee
+++ b/lib/data-store.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 Tingo = require('tingodb')({ memStore: true, nativeObjectID: false, searchInArray: true })

--- a/lib/data-store.coffee
+++ b/lib/data-store.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 Tingo = require('tingodb')({ memStore: true, nativeObjectID: false, searchInArray: true })
 

--- a/lib/errors.coffee
+++ b/lib/errors.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 errors =
   InternalError:

--- a/lib/errors.coffee
+++ b/lib/errors.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 errors =

--- a/lib/proxy.coffee
+++ b/lib/proxy.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 http = require 'http'

--- a/lib/proxy.coffee
+++ b/lib/proxy.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 http = require 'http'
 express = require 'express'

--- a/lib/routes/collection-access.coffee
+++ b/lib/routes/collection-access.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 _ = require 'underscore'

--- a/lib/routes/collection-access.coffee
+++ b/lib/routes/collection-access.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,8 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
+
 _ = require 'underscore'
 async = require 'async'
 errors = require '../errors'

--- a/lib/routes/configuration.coffee
+++ b/lib/routes/configuration.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 async = require 'async'

--- a/lib/routes/configuration.coffee
+++ b/lib/routes/configuration.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 async = require 'async'
 Busboy = require 'busboy'

--- a/lib/routes/email.coffee
+++ b/lib/routes/email.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 dataStore = require '../data-store'

--- a/lib/routes/email.coffee
+++ b/lib/routes/email.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 dataStore = require '../data-store'
 errors = require '../errors'

--- a/lib/routes/interface.coffee
+++ b/lib/routes/interface.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 express = require 'express'
 dataStore = require '../data-store'

--- a/lib/routes/interface.coffee
+++ b/lib/routes/interface.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 express = require 'express'

--- a/lib/routes/logging.coffee
+++ b/lib/routes/logging.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 dataStore = require '../data-store'

--- a/lib/routes/logging.coffee
+++ b/lib/routes/logging.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 dataStore = require '../data-store'
 errors = require '../errors'

--- a/lib/routes/push.coffee
+++ b/lib/routes/push.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 dataStore = require '../data-store'

--- a/lib/routes/push.coffee
+++ b/lib/routes/push.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 dataStore = require '../data-store'
 errors = require '../errors'

--- a/package.json
+++ b/package.json
@@ -23,27 +23,27 @@
     "test-push"             : "mocha test/lib/push.test.coffee"
   },
   "dependencies": {
-    "async": "1.4.x",
-    "body-parser": "1.13.x",
+    "async": "1.4.2",
+    "body-parser": "1.13.3",
     "bson": "0.2.15",
-    "busboy": "0.2.x",
+    "busboy": "0.2.11",
     "business-logic-local-dashboard": "Kinvey/business-logic-local-dashboard.git#0.1.0",
-    "coffee-script": "1.10.x",
-    "config": "1.16.x",
-    "cors": "2.7.x",
-    "express": "4.13.x",
-    "JSONStream": "0.10.x",
-    "jszip": "2.5.x",
+    "coffee-script": "1.10.0",
+    "config": "1.16.0",
+    "cors": "2.7.1",
+    "express": "4.13.3",
+    "JSONStream": "0.10.0",
+    "jszip": "2.5.0",
     "tingodb": "0.3.4",
-    "underscore": "1.8.x",
-    "uuid": "2.0.x"
+    "underscore": "1.8.3",
+    "uuid": "2.0.1"
   },
   "devDependencies": {
-    "coffeelint" : "1.11.x",
-    "mocha"      : "2.3.x",
-    "node-zip"   : "1.1.x",
-    "request"    : "2.62.x",
-    "should"     : "7.1.x"
+    "coffeelint" : "1.11.1",
+    "mocha"      : "2.3.2",
+    "node-zip"   : "1.1.1",
+    "request"    : "2.62.0",
+    "should"     : "7.1.0"
   },
   "engines": { "node": "= 0.10.x" }
 }

--- a/package.json
+++ b/package.json
@@ -1,43 +1,49 @@
 {
-  "name": "business-logic-mock-proxy",
-  "version": "0.0.2",
-  "description": "Business Logic Mock Proxy",
-  "engines": {
-    "node": "= 0.10.x"
+  "name"         : "business-logic-mock-proxy",
+  "version"      : "0.1.0",
+  "description"  : "Business Logic Mock Proxy",
+  "private"      : true,
+  "homepage"     : "http://www.kinvey.com",
+  "bugs"         : "https://github.com/Kinvey/business-logic-mock-proxy/issues",
+  "license"      : "Apache-2.0",
+  "author"       : "Kinvey, Inc.",
+  "contributors" : [
+    "Michael Salinger <mjsalinger@kinvey.com>",
+    "Mark van Seventer <mark@kinvey.com>"
+  ],
+  "repository" : { "type": "git", "url": "Kinvey/business-logic-mock-proxy" },
+  "scripts"    : {
+    "start"   : "node .",
+    "pretest" : "coffeelint -f .coffeelint config lib test",
+    "test"    : "mocha test/",
+    "test-collectionAccess" : "mocha test/lib/collection-access.test.coffee test/lib/collection-access-commands/*",
+    "test-configuration"    : "mocha test/lib/configuration-management.test.coffee",
+    "test-email"            : "mocha test/lib/email.test.coffee",
+    "test-logging"          : "mocha test/lib/logging.test.coffee",
+    "test-push"             : "mocha test/lib/push.test.coffee"
   },
   "dependencies": {
-    "business-logic-local-dashboard": "git+ssh://git@github.com:Kinvey/business-logic-local-dashboard.git#0.0.2",
-    "JSONStream": "^0.10.0",
-    "async": "0.9.0",
-    "body-parser": "1.6.5",
-    "bower": "^1.3.12",
+    "async": "1.4.x",
+    "body-parser": "1.13.x",
     "bson": "0.2.15",
-    "busboy": "^0.2.9",
-    "coffeelint": "^1.8.1",
-    "config": "1.0.2",
-    "cors": "^2.5.2",
-    "express": "4.8.5",
-    "jszip": "^2.4.0",
+    "busboy": "0.2.x",
+    "business-logic-local-dashboard": "Kinvey/business-logic-local-dashboard.git#0.1.0",
+    "coffee-script": "1.10.x",
+    "config": "1.16.x",
+    "cors": "2.7.x",
+    "express": "4.13.x",
+    "JSONStream": "0.10.x",
+    "jszip": "2.5.x",
     "tingodb": "0.3.4",
-    "underscore": "^1.7.0",
-    "uuid": "1.4.1"
+    "underscore": "1.8.x",
+    "uuid": "2.0.x"
   },
   "devDependencies": {
-    "async": "^0.9.0",
-    "coffee-script": "1.7.1",
-    "mocha": "1.21.4",
-    "node-zip": "^1.1.0",
-    "request": "^2.40.0",
-    "should": "3.3.2"
+    "coffeelint" : "1.11.x",
+    "mocha"      : "2.3.x",
+    "node-zip"   : "1.1.x",
+    "request"    : "2.62.x",
+    "should"     : "7.1.x"
   },
-  "scripts": {
-    "start": "node .",
-    "pretest": "coffeelint -f .coffeelint config lib test",
-    "test": "mocha test/",
-    "test-logging": "mocha test/lib/logging.test.coffee",
-    "test-collectionAccess": "mocha test/lib/collection-access.test.coffee test/lib/collection-access-commands/*",
-    "test-email": "mocha test/lib/email.test.coffee",
-    "test-push": "mocha test/lib/push.test.coffee",
-    "test-configuration": "mocha test/lib/configuration-management.test.coffee"
-  }
+  "engines": { "node": "= 0.10.x" }
 }

--- a/test/lib/collection-access-commands/collection-exists.test.coffee
+++ b/test/lib/collection-access-commands/collection-exists.test.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 config = require 'config'

--- a/test/lib/collection-access-commands/collection-exists.test.coffee
+++ b/test/lib/collection-access-commands/collection-exists.test.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 config = require 'config'
 should = require 'should'

--- a/test/lib/collection-access-commands/count.test.coffee
+++ b/test/lib/collection-access-commands/count.test.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,8 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
+
 config = require 'config'
 should = require 'should'
 request = require 'request'

--- a/test/lib/collection-access-commands/count.test.coffee
+++ b/test/lib/collection-access-commands/count.test.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 config = require 'config'

--- a/test/lib/collection-access-commands/distinct.test.coffee
+++ b/test/lib/collection-access-commands/distinct.test.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 config = require 'config'

--- a/test/lib/collection-access-commands/distinct.test.coffee
+++ b/test/lib/collection-access-commands/distinct.test.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 config = require 'config'
 should = require 'should'

--- a/test/lib/collection-access-commands/find-and-modify.test.coffee
+++ b/test/lib/collection-access-commands/find-and-modify.test.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 config = require 'config'

--- a/test/lib/collection-access-commands/find-and-modify.test.coffee
+++ b/test/lib/collection-access-commands/find-and-modify.test.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 config = require 'config'
 should = require 'should'

--- a/test/lib/collection-access-commands/find-and-remove.test.coffee
+++ b/test/lib/collection-access-commands/find-and-remove.test.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 config = require 'config'

--- a/test/lib/collection-access-commands/find-and-remove.test.coffee
+++ b/test/lib/collection-access-commands/find-and-remove.test.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 config = require 'config'
 should = require 'should'

--- a/test/lib/collection-access-commands/find.test.coffee
+++ b/test/lib/collection-access-commands/find.test.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 config = require 'config'

--- a/test/lib/collection-access-commands/find.test.coffee
+++ b/test/lib/collection-access-commands/find.test.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 config = require 'config'
 should = require 'should'

--- a/test/lib/collection-access-commands/findOne.test.coffee
+++ b/test/lib/collection-access-commands/findOne.test.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 config = require 'config'

--- a/test/lib/collection-access-commands/findOne.test.coffee
+++ b/test/lib/collection-access-commands/findOne.test.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 config = require 'config'
 should = require 'should'

--- a/test/lib/collection-access-commands/geoNear.test.coffee
+++ b/test/lib/collection-access-commands/geoNear.test.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 config = require 'config'

--- a/test/lib/collection-access-commands/geoNear.test.coffee
+++ b/test/lib/collection-access-commands/geoNear.test.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 config = require 'config'
 should = require 'should'

--- a/test/lib/collection-access-commands/group.test.coffee
+++ b/test/lib/collection-access-commands/group.test.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 config = require 'config'

--- a/test/lib/collection-access-commands/group.test.coffee
+++ b/test/lib/collection-access-commands/group.test.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 config = require 'config'
 should = require 'should'

--- a/test/lib/collection-access-commands/insert.test.coffee
+++ b/test/lib/collection-access-commands/insert.test.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 config = require 'config'

--- a/test/lib/collection-access-commands/insert.test.coffee
+++ b/test/lib/collection-access-commands/insert.test.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 config = require 'config'
 should = require 'should'

--- a/test/lib/collection-access-commands/map-reduce.test.coffee
+++ b/test/lib/collection-access-commands/map-reduce.test.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 config = require 'config'

--- a/test/lib/collection-access-commands/map-reduce.test.coffee
+++ b/test/lib/collection-access-commands/map-reduce.test.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 config = require 'config'
 should = require 'should'

--- a/test/lib/collection-access-commands/remove.test.coffee
+++ b/test/lib/collection-access-commands/remove.test.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 config = require 'config'

--- a/test/lib/collection-access-commands/remove.test.coffee
+++ b/test/lib/collection-access-commands/remove.test.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 config = require 'config'
 should = require 'should'

--- a/test/lib/collection-access-commands/save.test.coffee
+++ b/test/lib/collection-access-commands/save.test.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 config = require 'config'

--- a/test/lib/collection-access-commands/save.test.coffee
+++ b/test/lib/collection-access-commands/save.test.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 config = require 'config'
 should = require 'should'

--- a/test/lib/collection-access-commands/update.test.coffee
+++ b/test/lib/collection-access-commands/update.test.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 config = require 'config'

--- a/test/lib/collection-access-commands/update.test.coffee
+++ b/test/lib/collection-access-commands/update.test.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 config = require 'config'
 should = require 'should'

--- a/test/lib/collection-access.test.coffee
+++ b/test/lib/collection-access.test.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 request = require 'request'

--- a/test/lib/collection-access.test.coffee
+++ b/test/lib/collection-access.test.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 request = require 'request'
 config = require 'config'

--- a/test/lib/configuration-management.test.coffee
+++ b/test/lib/configuration-management.test.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 fs = require 'fs'
 unzip = require 'node-zip'
@@ -221,7 +223,7 @@ describe 'Configuration management', () ->
           body = JSON.parse body
           body.code.should.eql 'DataImportError'
           done()
-    
+
     it 'returns an array of mongo errors encountered while trying to insert data', (done) ->
       req.post
         url: "#{baseUrl}/configuration/collectionData/import?collectionName=#{collectionName}"

--- a/test/lib/configuration-management.test.coffee
+++ b/test/lib/configuration-management.test.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 fs = require 'fs'

--- a/test/lib/email.test.coffee
+++ b/test/lib/email.test.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 async = require 'async'

--- a/test/lib/email.test.coffee
+++ b/test/lib/email.test.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 async = require 'async'
 config = require 'config'

--- a/test/lib/logging.test.coffee
+++ b/test/lib/logging.test.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 async = require 'async'

--- a/test/lib/logging.test.coffee
+++ b/test/lib/logging.test.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 async = require 'async'
 config = require 'config'

--- a/test/lib/push.test.coffee
+++ b/test/lib/push.test.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 config = require 'config'

--- a/test/lib/push.test.coffee
+++ b/test/lib/push.test.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 config = require 'config'
 should = require 'should'

--- a/test/testUtils.coffee
+++ b/test/testUtils.coffee
@@ -1,16 +1,17 @@
 #
-# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
+# Copyright 2015 Kinvey, Inc.
 #
-# This software is licensed to you under the Kinvey terms of service located at
-# http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
-# software, you hereby accept such terms of service  (and any agreement referenced
-# therein) and agree that you have read, understand and agree to be bound by such
-# terms of service and are of legal age to agree to such terms with Kinvey.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
 #
-# This software contains valuable confidential and proprietary information of
-# KINVEY, INC and is subject to applicable licensing agreements.
-# Unauthorized reproduction, transmission or distribution of this file and its
-# contents is a violation of applicable laws.
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 #
 
 cp = require 'child_process'

--- a/test/testUtils.coffee
+++ b/test/testUtils.coffee
@@ -1,4 +1,5 @@
-# Copyright (c) 2014, Kinvey, Inc. All rights reserved.
+#
+# Copyright (c) 2015, Kinvey, Inc. All rights reserved.
 #
 # This software is licensed to you under the Kinvey terms of service located at
 # http://www.kinvey.com/terms-of-use. By downloading, accessing and/or using this
@@ -10,6 +11,7 @@
 # KINVEY, INC and is subject to applicable licensing agreements.
 # Unauthorized reproduction, transmission or distribution of this file and its
 # contents is a violation of applicable laws.
+#
 
 cp = require 'child_process'
 async = require 'async'


### PR DESCRIPTION
This PR adds the Dockerfile used to build the public `kinvey/bl-mock-proxy` image used when testing BL locally. Since this repo is now public, the license file and copyright headers are updated to the latest state.

Final note: even though this repo is now public, we don't have to `npm publish` this, we can just refer to the GitHub URL in `package.json`. Right now, the best way to consume this repo is through its Docker image anyway.
